### PR TITLE
Fix #49: add support for more HTTP methods

### DIFF
--- a/amx/server/syscalls.lua
+++ b/amx/server/syscalls.lua
@@ -2763,15 +2763,37 @@ function SetPlayerChatBubble(amx, player, text, color, dist, exptime)
 end
 
 
--- In MTA we can't set the type of the request. 
--- When we add 'data' it becomes POST request.
--- TODO: arguments "index" and "type" here only for compatibility.
+-- Now we have all of RESTful types of requests. Our function is better!
+-- The SAMP documentation said about 'url' - "The URL you want to request. (Without 'http://')"
+-- But I didn't set it up. Because WE SUPPORT HTTPS!
+-- TODO: An "index" argument only for compatibility.
 function HTTP(amx, index, type, url, data, callback)
-	if type == 3 then 
-		notImplemented('HTTP', 'A HEAD type have not support right now')
-	end
-	local request = fetchRemote ("http://".. url, 
-	function(responseData, error)
+
+	local typesToText = {
+		'GET',
+		'POST',
+		'HEAD',
+		'PUT',
+		'PATCH',
+		'DELETE',
+		'COPY',
+		'OPTIONS',
+		'LINK',
+		'UNLINK',
+		'PURGE',
+		'LOCK',
+		'UNLOCK',
+		'PROPFIND',
+		'VIEW'
+	}
+	local sendOptions = {
+		queueName = "A SAMP request queue",
+		postData = data,
+		method = typesToText[tonumber(type)],
+	}
+	fetchRemote(url, sendOptions, 
+	function (responseData, responseInfo)
+		local error = responseInfo.statusCode
 		if error == 0 then
 			procCallInternal(amx, callback, index, 200, responseData)
 			return 1;
@@ -2788,7 +2810,7 @@ function HTTP(amx, index, type, url, data, callback)
 			procCallInternal(amx, callback, index, error, responseData)
 			return 0;
 		end
-	end, data, false)
+	end)
 	return 0;
 end
 

--- a/amx/server/syscalls.lua
+++ b/amx/server/syscalls.lua
@@ -2814,7 +2814,7 @@ function HTTP(amx, index, type, url, data, callback)
 			procCallInternal(amx, callback, index, error, responseData)
 		end
 	end)
-	if not success then
+	if not successRemote then
 		return 0
 	end
 	return 1

--- a/amx/server/syscalls.lua
+++ b/amx/server/syscalls.lua
@@ -2765,53 +2765,59 @@ end
 
 -- Now we have all of RESTful types of requests. Our function is better!
 -- The SAMP documentation said about 'url' - "The URL you want to request. (Without 'http://')"
--- But I didn't set it up. Because WE SUPPORT HTTPS!
+-- I made a check. The state without a protocol is called as 'default'.
+-- HTTP and HTTPS you can put into URL if you want. It works fine.
 -- TODO: An "index" argument only for compatibility.
 function HTTP(amx, index, type, url, data, callback)
 
+	local protomatch = pregMatch(url,'^(\\w+):\\/\\/')
+	local proto = protomatch[1] or 'default'
+	-- if somebody will try to put here ftp:// ssh:// etc...
+	if proto ~= 'http' and proto ~= 'https' and proto ~= 'default' then
+		print('Current protocol is not supporting')
+		return 0
+	end
 	local typesToText = {
 		'GET',
 		'POST',
 		'HEAD',
-		'PUT',
-		'PATCH',
-		'DELETE',
-		'COPY',
-		'OPTIONS',
-		'LINK',
-		'UNLINK',
-		'PURGE',
-		'LOCK',
-		'UNLOCK',
-		'PROPFIND',
-		'VIEW'
+		[-4] = 'PUT',
+		[-5] = 'PATCH',
+		[-6] = 'DELETE',
+		[-7] = 'COPY',
+		[-8] = 'OPTIONS',
+		[-9] = 'LINK',
+		[-10] = 'UNLINK',
+		[-11] = 'PURGE',
+		[-12] = 'LOCK',
+		[-13] = 'UNLOCK',
+		[-14] = 'PROPFIND',
+		[-15] = 'VIEW'
 	}
 	local sendOptions = {
-		queueName = "A SAMP request queue",
+		queueName = "amx." .. getResourceName(amx.res) .. "." .. amx.name,
 		postData = data,
 		method = typesToText[tonumber(type)],
 	}
-	fetchRemote(url, sendOptions, 
+	local successRemote = fetchRemote(url, sendOptions, 
 	function (responseData, responseInfo)
 		local error = responseInfo.statusCode
 		if error == 0 then
 			procCallInternal(amx, callback, index, 200, responseData)
-			return 1;
 		elseif error >= 1 and error <= 89 then
 			procCallInternal(amx, callback, index, 3, responseData)
-			return 0;
 		elseif error == 1006 or error == 1005 then
 			procCallInternal(amx, callback, index, 1, responseData)
-			return 0;
 		elseif error == 1007 then 
 			procCallInternal(amx, callback, index, 5, responseData)	
-			return 0;
 		else
 			procCallInternal(amx, callback, index, error, responseData)
-			return 0;
 		end
 	end)
-	return 0;
+	if not success then
+		return 0
+	end
+	return 1
 end
 
 function Create3DTextLabel(amx, text, r, g, b, a, x, y, z, dist, vw, los)


### PR DESCRIPTION
fixes #49
In this version people can choose a type of request.
Available types:
```
1. GET
2. POST
3. HEAD
4. PUT
5. PATCH
6. DELETE
7. COPY
8. OPTIONS
9. LINK
10. UNLINK
11. PURGE
12. LOCK
13. UNLOCK
14. PROPFIND
15. VIEW
```

Same I allowed to using HTTPS protocol. (see comments in the code)